### PR TITLE
Add hardware management web scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Test
+# Test Repository for Hardware Management

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,16 @@
+// Placeholder for a backend server connecting to localhost\\SQLEXPRESS
+// In einer echten Anwendung würde hier die Verbindung zur SQL-Datenbank
+// hergestellt und eine API bereitgestellt.
+
+// Beispiel mit Node.js und dem Paket 'mssql':
+// const sql = require('mssql');
+// const config = {
+//     server: 'localhost\\SQLEXPRESS',
+//     database: 'HardwareDB',
+//     options: {
+//         trustedConnection: true
+//     }
+// };
+// sql.connect(config).then(() => {
+//     // API-Endpunkte definieren
+// });

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,66 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+
+.hardware-form,
+.hardware-list {
+    max-width: 800px;
+    margin: 2rem auto;
+    background: #fff;
+    padding: 1rem;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+label {
+    display: block;
+    margin-top: 0.5rem;
+}
+
+input {
+    width: 100%;
+    padding: 0.5rem;
+    margin-top: 0.2rem;
+    box-sizing: border-box;
+}
+
+button {
+    margin-top: 1rem;
+    padding: 0.7rem 1.5rem;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+#hardwareTable {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+#hardwareTable th,
+#hardwareTable td {
+    border: 1px solid #ddd;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+#hardwareTable th {
+    background-color: #f2f2f2;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hardware Verwaltung</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>Hardware Verwaltung</h1>
+    </header>
+
+    <section class="hardware-form">
+        <h2>Neue Hardware hinzufügen</h2>
+        <form id="hardwareForm">
+            <label for="name">Name:</label>
+            <input type="text" id="name" name="name" required>
+
+            <label for="type">Typ:</label>
+            <input type="text" id="type" name="type" required>
+
+            <label for="serial">Seriennummer:</label>
+            <input type="text" id="serial" name="serial" required>
+
+            <button type="submit">Speichern</button>
+        </form>
+    </section>
+
+    <section class="hardware-list">
+        <h2>Geräteliste</h2>
+        <table id="hardwareTable">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Typ</th>
+                    <th>Seriennummer</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Geräte werden hier eingefügt -->
+            </tbody>
+        </table>
+    </section>
+
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,33 @@
+// Einfaches Array, um Hardware-Daten im Browser zu speichern
+const hardwareItems = [];
+
+// Formular-Handling
+const form = document.getElementById('hardwareForm');
+const tableBody = document.querySelector('#hardwareTable tbody');
+
+form.addEventListener('submit', function (e) {
+    e.preventDefault();
+
+    const name = document.getElementById('name').value;
+    const type = document.getElementById('type').value;
+    const serial = document.getElementById('serial').value;
+
+    const item = { name, type, serial };
+    hardwareItems.push(item);
+
+    addItemToTable(item);
+    form.reset();
+
+    // Hier könnte ein AJAX-Aufruf erfolgen, um die Daten an einen Server zu senden
+    // Beispiel: fetch('/api/hardware', { method: 'POST', body: JSON.stringify(item) })
+});
+
+function addItemToTable(item) {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+        <td>${item.name}</td>
+        <td>${item.type}</td>
+        <td>${item.serial}</td>
+    `;
+    tableBody.appendChild(row);
+}


### PR DESCRIPTION
## Summary
- add HTML for a small hardware management UI
- style the page
- provide JavaScript to add hardware entries to the table
- stub out a backend connection to `localhost\SQLEXPRESS`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68666fa56800832dbf18fbec53f24a57