### PR TITLE
Create simple start page with links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Test Repository for Hardware Management
+
+Diese Demo-Anwendung enthält eine einfache Startseite mit Links zur Hardware-
+und Softwareverwaltung sowie einer Kontaktseite.
+
+* `index.html` – Startseite mit drei Buttons
+* `hardware.html` – bisherige Hardware-Verwaltung
+* `software.html` – Platzhalter für Software-Verwaltung
+* `kontakt.html` – Kontaktinformationen
+
+Jede dieser Seiten besitzt nun eine eigene CSS-Datei im Verzeichnis `css/`:
+* `index.css`
+* `hardware.css`
+* `software.css`
+* `kontakt.css`

--- a/css/hardware.css
+++ b/css/hardware.css
@@ -1,0 +1,8 @@
+/* Styles spezifisch für die Hardware-Seite */
+.hardware-form button {
+    background-color: #28a745;
+}
+
+.hardware-form button:hover {
+    background-color: #1e7e34;
+}

--- a/css/index.css
+++ b/css/index.css
@@ -1,0 +1,4 @@
+/* Zusätzliche Styles für die Startseite */
+.start-container {
+    margin-top: 3rem;
+}

--- a/css/kontakt.css
+++ b/css/kontakt.css
@@ -1,0 +1,8 @@
+/* Styles für die Kontakt-Seite */
+a {
+    color: #007bff;
+}
+
+a:hover {
+    text-decoration: underline;
+}

--- a/css/software.css
+++ b/css/software.css
@@ -1,0 +1,6 @@
+/* Styles für die Software-Seite */
+.placeholder {
+    text-align: center;
+    font-style: italic;
+    margin-top: 2rem;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -64,3 +64,24 @@ button:hover {
 #hardwareTable th {
     background-color: #f2f2f2;
 }
+
+/* Startseite */
+.start-container {
+    max-width: 600px;
+    margin: 2rem auto;
+    text-align: center;
+}
+
+.nav-button {
+    display: inline-block;
+    margin: 1rem;
+    padding: 0.7rem 1.5rem;
+    background-color: #007bff;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+.nav-button:hover {
+    background-color: #0056b3;
+}

--- a/hardware.html
+++ b/hardware.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hardware Verwaltung</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/hardware.css">
+</head>
+<body>
+    <header>
+        <h1>Hardware Verwaltung</h1>
+    </header>
+
+    <section class="hardware-form">
+        <h2>Neue Hardware hinzufügen</h2>
+        <form id="hardwareForm">
+            <label for="name">Name:</label>
+            <input type="text" id="name" name="name" required>
+
+            <label for="type">Typ:</label>
+            <input type="text" id="type" name="type" required>
+
+            <label for="serial">Seriennummer:</label>
+            <input type="text" id="serial" name="serial" required>
+
+            <button type="submit">Speichern</button>
+        </form>
+    </section>
+
+    <section class="hardware-list">
+        <h2>Geräteliste</h2>
+        <table id="hardwareTable">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Typ</th>
+                    <th>Seriennummer</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Geräte werden hier eingefügt -->
+            </tbody>
+        </table>
+    </section>
+
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,46 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hardware Verwaltung</title>
+    <title>Startseite</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/index.css">
 </head>
 <body>
     <header>
-        <h1>Hardware Verwaltung</h1>
+        <h1>Willkommen zur Verwaltung</h1>
     </header>
-
-    <section class="hardware-form">
-        <h2>Neue Hardware hinzufügen</h2>
-        <form id="hardwareForm">
-            <label for="name">Name:</label>
-            <input type="text" id="name" name="name" required>
-
-            <label for="type">Typ:</label>
-            <input type="text" id="type" name="type" required>
-
-            <label for="serial">Seriennummer:</label>
-            <input type="text" id="serial" name="serial" required>
-
-            <button type="submit">Speichern</button>
-        </form>
-    </section>
-
-    <section class="hardware-list">
-        <h2>Geräteliste</h2>
-        <table id="hardwareTable">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Typ</th>
-                    <th>Seriennummer</th>
-                </tr>
-            </thead>
-            <tbody>
-                <!-- Geräte werden hier eingefügt -->
-            </tbody>
-        </table>
-    </section>
-
-    <script src="js/app.js"></script>
+    <div class="start-container">
+        <a class="nav-button" href="hardware.html">Hardware</a>
+        <a class="nav-button" href="software.html">Software</a>
+        <a class="nav-button" href="kontakt.html">Kontakt</a>
+    </div>
 </body>
 </html>

--- a/kontakt.html
+++ b/kontakt.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kontakt</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/kontakt.css">
+</head>
+<body>
+    <header>
+        <h1>Kontakt</h1>
+    </header>
+    <p>Bei Fragen erreichen Sie uns unter <a href="mailto:info@example.com">info@example.com</a>.</p>
+</body>
+</html>

--- a/software.html
+++ b/software.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Software Verwaltung</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/software.css">
+</head>
+<body>
+    <header>
+        <h1>Software Verwaltung</h1>
+    </header>
+    <p class="placeholder">Diese Seite ist noch in Arbeit.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a start page with buttons for hardware, software and contact
- move existing hardware management UI to `hardware.html`
- create placeholder pages for software and contact
- update styles for navigation buttons
- update README with new structure
- add page-specific CSS files

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686670f3f120832d9b12bb75c68e0a82